### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ITSkill365DevOps/c527abf7-d198-4953-96c7-f8ebe8584733/16aee154-db81-4fe8-bf57-a1f0ef53f905/_apis/work/boardbadge/77973cd3-ba7f-4e78-addd-a2afadd61bcc)](https://dev.azure.com/ITSkill365DevOps/c527abf7-d198-4953-96c7-f8ebe8584733/_boards/board/t/16aee154-db81-4fe8-bf57-a1f0ef53f905/Microsoft.RequirementCategory)
 Update 3
 
 This is sample Python Flask application.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/ITSkill365DevOps/c527abf7-d198-4953-96c7-f8ebe8584733/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.